### PR TITLE
Token List Class Wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If not specified, it will fall back onto the semantics described in `displayOpti
 
 Type: `Object`
 
-Allowed Keys: `input`, `results`, `listItem`, `listAnchor`, `hover`, `resultsTruncated`. For the **Tokenizer** you can also provide `token`, `typeahead`.
+Allowed Keys: `input`, `results`, `listItem`, `listAnchor`, `hover`, `resultsTruncated`. For the **Tokenizer** you can also provide `token`, `typeahead` and `tokenList`.
 
 An object containing custom class names for child elements. Useful for
 integrating with 3rd party UI kits.

--- a/src/Tokenizer/index.tsx
+++ b/src/Tokenizer/index.tsx
@@ -8,30 +8,30 @@ import useTokenManager from './helpers/useTokenManager';
 
 export interface Props<Opt extends Option>
   extends Pick<
-  TypeaheadProps<Opt>,
-  | 'onChange'
-  | 'className'
-  | 'onBlur'
-  | 'onFocus'
-  | 'onKeyPress'
-  | 'onKeyUp'
-  | 'onKeyDown'
-  | 'name'
-  | 'initialValue'
-  | 'disabled'
-  | 'placeholder'
-  | 'filterOption'
-  | 'searchOptions'
-  | 'displayOption'
-  | 'formInputOption'
-  | 'innerRef'
-  | 'defaultClassNames'
-  | 'showOptionsWhenEmpty'
-  | 'maxVisible'
-  | 'inputProps'
-  | 'resultsTruncatedMessage'
-  >,
-  OptionsProps<Opt> {
+      TypeaheadProps<Opt>,
+      | 'onChange'
+      | 'className'
+      | 'onBlur'
+      | 'onFocus'
+      | 'onKeyPress'
+      | 'onKeyUp'
+      | 'onKeyDown'
+      | 'name'
+      | 'initialValue'
+      | 'disabled'
+      | 'placeholder'
+      | 'filterOption'
+      | 'searchOptions'
+      | 'displayOption'
+      | 'formInputOption'
+      | 'innerRef'
+      | 'defaultClassNames'
+      | 'showOptionsWhenEmpty'
+      | 'maxVisible'
+      | 'inputProps'
+      | 'resultsTruncatedMessage'
+    >,
+    OptionsProps<Opt> {
   customClasses?: TokenCustomClasses;
   defaultSelected?: Opt[];
   onTokenRemove?: (value: Opt) => void;
@@ -132,6 +132,8 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     return classNames(tokenizerClasses);
   }, [className, defaultClassNames]);
 
+  const tokenListBaseClass = 'typeahead-token-list';
+
   const args2Pass = {
     placeholder,
     disabled,
@@ -156,7 +158,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
   return (
     <div className={tokenizerClassList}>
       {renderAbove && (
-        <div className={customClasses.tokenList}>
+        <div className={`${tokenListBaseClass} ${customClasses.tokenList}`}>
           <Tokens
             name={name}
             selectedOptions={selected}
@@ -179,7 +181,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
         separateByComma={separateByComma}
       />
       {!renderAbove && (
-        <div className={customClasses.tokenList}>
+        <div className={`${tokenListBaseClass} ${customClasses.tokenList}`}>
           <Tokens
             name={name}
             selectedOptions={selected}

--- a/src/Tokenizer/index.tsx
+++ b/src/Tokenizer/index.tsx
@@ -164,19 +164,17 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
           removeTokenForValue={removeTokenForValue}
         />
       )}
-      {
-        <Typeahead
-          innerRef={typeaheadElement}
-          className={classList}
-          {...args2Pass}
-          options={cleanOptions}
+      <Typeahead
+        innerRef={typeaheadElement}
+        className={classList}
+        {...args2Pass}
+        options={cleanOptions}
           // @ts-ignore - onOptionSelect is impossible to match in 3.5.2
-          onOptionSelected={addTokenForValue}
-          onKeyDown={onKeyDown}
-          clearOnSelection
-          separateByComma={separateByComma}
-        />
-      }
+        onOptionSelected={addTokenForValue}
+        onKeyDown={onKeyDown}
+        clearOnSelection
+        separateByComma={separateByComma}
+      />
       {!renderAbove && (
         <Tokens
           name={name}

--- a/src/Tokenizer/index.tsx
+++ b/src/Tokenizer/index.tsx
@@ -77,7 +77,6 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     renderAbove,
     name,
     separateByComma,
-    tokenListClasses,
   } = React.useMemo(() => props, [props]);
 
   // Memo section
@@ -133,16 +132,6 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     return classNames(tokenizerClasses);
   }, [className, defaultClassNames]);
 
-  let allTokenListClasses = '';
-
-  if (tokenListClasses) {
-    allTokenListClasses = tokenListClasses.reduce(
-      (previousValue, currentValue) => {
-        return `${previousValue} ${currentValue}`;
-      }
-    );
-  }
-
   const args2Pass = {
     placeholder,
     disabled,
@@ -167,7 +156,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
   return (
     <div className={tokenizerClassList}>
       {renderAbove && (
-        <div className={allTokenListClasses}>
+        <div className={customClasses.tokenList}>
           <Tokens
             name={name}
             selectedOptions={selected}
@@ -190,7 +179,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
         separateByComma={separateByComma}
       />
       {!renderAbove && (
-        <div className={allTokenListClasses}>
+        <div className={customClasses.tokenList}>
           <Tokens
             name={name}
             selectedOptions={selected}

--- a/src/Tokenizer/index.tsx
+++ b/src/Tokenizer/index.tsx
@@ -8,36 +8,37 @@ import useTokenManager from './helpers/useTokenManager';
 
 export interface Props<Opt extends Option>
   extends Pick<
-      TypeaheadProps<Opt>,
-      | 'onChange'
-      | 'className'
-      | 'onBlur'
-      | 'onFocus'
-      | 'onKeyPress'
-      | 'onKeyUp'
-      | 'onKeyDown'
-      | 'name'
-      | 'initialValue'
-      | 'disabled'
-      | 'placeholder'
-      | 'filterOption'
-      | 'searchOptions'
-      | 'displayOption'
-      | 'formInputOption'
-      | 'innerRef'
-      | 'defaultClassNames'
-      | 'showOptionsWhenEmpty'
-      | 'maxVisible'
-      | 'inputProps'
-      | 'resultsTruncatedMessage'
-    >,
-    OptionsProps<Opt> {
+  TypeaheadProps<Opt>,
+  | 'onChange'
+  | 'className'
+  | 'onBlur'
+  | 'onFocus'
+  | 'onKeyPress'
+  | 'onKeyUp'
+  | 'onKeyDown'
+  | 'name'
+  | 'initialValue'
+  | 'disabled'
+  | 'placeholder'
+  | 'filterOption'
+  | 'searchOptions'
+  | 'displayOption'
+  | 'formInputOption'
+  | 'innerRef'
+  | 'defaultClassNames'
+  | 'showOptionsWhenEmpty'
+  | 'maxVisible'
+  | 'inputProps'
+  | 'resultsTruncatedMessage'
+  >,
+  OptionsProps<Opt> {
   customClasses?: TokenCustomClasses;
   defaultSelected?: Opt[];
   onTokenRemove?: (value: Opt) => void;
   onTokenAdd?: (value: Opt) => void;
   renderAbove?: boolean;
   separateByComma?: boolean;
+  tokenListClasses?: string[];
 }
 
 /**
@@ -76,6 +77,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     renderAbove,
     name,
     separateByComma,
+    tokenListClasses,
   } = React.useMemo(() => props, [props]);
 
   // Memo section
@@ -131,6 +133,16 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     return classNames(tokenizerClasses);
   }, [className, defaultClassNames]);
 
+  let allTokenListClasses = '';
+
+  if (tokenListClasses) {
+    allTokenListClasses = tokenListClasses.reduce(
+      (previousValue, currentValue) => {
+        return `${previousValue} ${currentValue}`;
+      }
+    );
+  }
+
   const args2Pass = {
     placeholder,
     disabled,
@@ -155,37 +167,41 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
   return (
     <div className={tokenizerClassList}>
       {renderAbove && (
-        <Tokens
-          name={name}
-          selectedOptions={selected}
-          token={customClasses.token}
-          formInputOption={formInputOption}
-          displayOption={displayOption}
-          removeTokenForValue={removeTokenForValue}
-        />
+        <div className={allTokenListClasses}>
+          <Tokens
+            name={name}
+            selectedOptions={selected}
+            token={customClasses.token}
+            formInputOption={formInputOption}
+            displayOption={displayOption}
+            removeTokenForValue={removeTokenForValue}
+          />
+        </div>
       )}
       <Typeahead
         innerRef={typeaheadElement}
         className={classList}
         {...args2Pass}
         options={cleanOptions}
-          // @ts-ignore - onOptionSelect is impossible to match in 3.5.2
+        // @ts-ignore - onOptionSelect is impossible to match in 3.5.2
         onOptionSelected={addTokenForValue}
         onKeyDown={onKeyDown}
         clearOnSelection
         separateByComma={separateByComma}
       />
       {!renderAbove && (
-        <Tokens
-          name={name}
-          selectedOptions={selected}
-          token={customClasses.token}
-          // @ts-ignore
-          formInputOption={formInputOption}
-          // @ts-ignore
-          displayOption={displayOption}
-          removeTokenForValue={removeTokenForValue}
-        />
+        <div className={allTokenListClasses}>
+          <Tokens
+            name={name}
+            selectedOptions={selected}
+            token={customClasses.token}
+            // @ts-ignore
+            formInputOption={formInputOption}
+            // @ts-ignore
+            displayOption={displayOption}
+            removeTokenForValue={removeTokenForValue}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface CustomClasses {
 export interface TokenCustomClasses extends CustomClasses {
   token?: string;
   typeahead?: string;
+  tokenList?: string;
 }
 
 export type EventType =


### PR DESCRIPTION
The Typeahead and Individual tokens can have custom classes set to them but there is nothing for the whole list of tokens itself.

By adding some extra divs and updating the `TokenCustomClasses` definition, this is now possible.